### PR TITLE
add: newly onboarded python instances from codearena

### DIFF
--- a/swebench/harness/constants/python.py
+++ b/swebench/harness/constants/python.py
@@ -902,11 +902,248 @@ SPECS_PYDICOM.update(
 
 SPECS_HUMANEVAL = {k: {"python": "3.9", "test_cmd": "python"} for k in ["1.0"]}
 
+SPECS_FASTAPI = {
+    k: {
+        "python": "3.7",
+        "install": "pip install -e '.[all, dev, test]'",
+        "pip_packages": [
+            "'flask<2.3.0'",
+            "websockets"
+        ],
+        "test_cmd": TEST_PYTEST_VERBOSE,
+    }
+    for k in ['0.87', '0.94', '0.68', '0.92', '0.79', '0.79', '0.55', '0.55', '0.57', '0.55', '0.55', '0.55', '0.52', '0.49', '0.47', '0.46', '0.45', '0.42', '0.42', '0.39', '0.35', '0.35', '0.35', '0.35', '0.31', '0.29']
+}
+
+SPECS_YOUTUBE_DL = {
+    k: {
+        "python": "3.7",
+        "install": "pip install -e '.[all, dev, test]'",
+        "pip_packages": [
+            "pytest"
+        ],
+        "test_cmd": TEST_PYTEST_VERBOSE,
+    }
+    for k in ['2021.12', '2019.11']
+}
+
+SPECS_KERAS = {
+    k: {
+        "python": "3.10",
+        "pip_packages": [
+            'namex>=0.0.8',
+            'ruff',
+            'pytest',
+            'numpy',
+            'scipy',
+            'scikit-learn',
+            'pandas',
+            'absl-py',
+            'requests',
+            'h5py',
+            'ml-dtypes',
+            'protobuf',
+            'google',
+            'tensorboard-plugin-profile',
+            'rich',
+            'build',
+            'optree',
+            'pytest-cov',
+            'packaging',
+            # for tree_test.py
+            'dm_tree',
+            'coverage!=7.6.5',  # 7.6.5 breaks CI
+            # for onnx_test.py
+            'onnxruntime',
+            # Tensorflow.
+            "tensorflow~=2.18.0",
+            'tf_keras',
+            'tf2onnx',
+            # Torch.
+            'torch>=2.1.0',
+            'torchvision>=0.16.0',
+            'torch-xla',
+            # Jax.
+            'jax[cpu]',
+            'flax',
+        ],
+        # "install": "python pip_build.py --install",
+        "install": "python -m pip install -e .",
+        "test_cmd": TEST_PYTEST,
+    }
+    for k in ['3.3', '3.4', '3.5', '3.6', '3.7', '3.8', 'None']
+}
+
+SPECS_CAMEL = {
+    k: {
+        "python": "3.10",
+        "install": "pip install -e '.[all, dev, test]'",
+        "pip_packages" : ["'gradio'"],
+        "test_cmd": TEST_PYTEST_VERBOSE,
+    }
+    for k in ["0.2"]
+}
+
+SPECS_SCRAPY = {
+    **{
+        k: {
+            "python": "3.9",
+            "install": "pip install -e '.'",
+            "pip_packages": [
+                "boto3",
+                "google-cloud-storage",
+                "tox",
+                "testfixtures",
+                "pytest",
+                "sock",
+                "pillow",
+                "botocore",
+                "pexpect",
+                "uvloop",
+                "zstd",
+                "brotli",
+                "twisted",
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE,
+        }
+        for k in ['2.6', '2.5']
+    },
+    **{
+        k: {
+            "python": "3.9",
+            "install": "pip install -e '.'",
+            "pip_packages": [
+                "tox",
+                "testfixtures",
+                "pytest",
+                "pexpect",
+                "botocore",
+                "boto3",
+                "google-cloud-storage",
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE,
+        }
+        for k in ["2.7", "2.8", "2.9"]
+    },
+    **{
+        k: {
+            "python": "3.9",
+            "install": "pip install -e '.'",
+            "pip_packages": [
+                "tox",
+                "testfixtures",
+                "pytest",
+                "pexpect",
+                "sock",
+                "pillow",
+                "botocore",
+                "uvloop",
+                "zstd",
+                "brotli",
+                "twisted",
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE,
+        }
+        for k in ["2.12", "2.11", "2.10"]
+    }
+}
+
+SPECS_CELERY = {
+    ** {
+        k: {
+            "python": "3.9",
+            "install": "pip install -U -r requirements/test.txt",
+            "pip_packages": [
+                "pytest==8.3.4",
+                "pytest-xdist",
+                "pytest-timeout",
+                "pytest-subtests",
+                "redis",
+                "kombu",
+                "vine",
+                "amqp",
+                "case",
+                "billiard",
+                "nose",
+                "importlib-metadata",
+                "importlib-resources",
+                "pydantic",
+                "dnspython",
+                "pymongo==4.10.1",
+                "django-celery",
+                "elasticsearch",
+                "sqlalchemy==2.0.38",
+                "python-memcached==1.62",
+                "tblib",
+                "pytz",
+                "ephem==4.2.0"
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE
+        }
+        for k in ["5.1", "5.2", "5.3", "5.4", "5.5"]
+    },
+    **{
+        k: {
+            "python": "3.9",
+            "install": "",
+            "pip_packages": [
+                "pytest==7.1.3",
+                "pytest-xdist==2.5.0",
+                "pytest-timeout",
+                "pytest-subtests==0.10.0",
+                "pytest-cov==2.12.1",
+                "case",
+                "kombu",
+                "billiard",
+                "pytz",
+                "click",
+                "flaky",
+                "vine==1.3.0",
+                "redis",
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE
+        }
+        for k in ["5.0"]
+    },
+    ** {
+        k: {
+            "python": "3.9",
+            "install": "",
+            "pip_packages": [
+                "pytest==7.1.3",
+                "pytest-xdist==2.5.0",
+                "pytest-timeout",
+                "pytest-subtests==0.10.0",
+                "pytest-cov==2.12.1",
+                "case",
+                "kombu",
+                "billiard==3.6.4.0",
+                "pytz",
+                "click",
+                "flaky",
+                "vine==1.3.0",
+                "redis",
+                "boto3",
+                "cryptography",
+                "sqlalchemy",
+                "future",
+                "tblib",
+            ],
+            "test_cmd": TEST_PYTEST_VERBOSE
+            }
+            for k in ["4.2", "4.3", "4.4"]
+    }
+}
+
 # Constants - Task Instance Instllation Environment
 MAP_REPO_VERSION_TO_SPECS_PY = {
     "astropy/astropy": SPECS_ASTROPY,
+    "camel-ai/camel": SPECS_CAMEL,
+    "celery/celery": SPECS_CELERY,
     "dbt-labs/dbt-core": SPECS_DBT_CORE,
     "django/django": SPECS_DJANGO,
+    "fastapi/fastapi": SPECS_FASTAPI,
+    "keras-team/keras": SPECS_KERAS,
     "matplotlib/matplotlib": SPECS_MATPLOTLIB,
     "marshmallow-code/marshmallow": SPECS_MARSHMALLOW,
     "mwaskom/seaborn": SPECS_SEABORN,
@@ -920,10 +1157,12 @@ MAP_REPO_VERSION_TO_SPECS_PY = {
     "pytest-dev/pytest": SPECS_PYTEST,
     "pyvista/pyvista": SPECS_PYVISTA,
     "scikit-learn/scikit-learn": SPECS_SKLEARN,
+    "scrapy/scrapy": SPECS_SCRAPY,
     "sphinx-doc/sphinx": SPECS_SPHINX,
     "sqlfluff/sqlfluff": SPECS_SQLFLUFF,
     "swe-bench/humaneval": SPECS_HUMANEVAL,
     "sympy/sympy": SPECS_SYMPY,
+    "ytdl-org/youtube-dl": SPECS_YOUTUBE_DL,
 }
 
 # Constants - Repository Specific Installation Instructions

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -257,6 +257,12 @@ parse_log_pvlib = parse_log_pytest
 parse_log_pyvista = parse_log_pytest
 parse_log_sqlfluff = parse_log_pytest
 parse_log_xarray = parse_log_pytest
+parse_log_fastapi = parse_log_pytest
+parse_log_youtube = parse_log_pytest
+parse_log_keras = parse_log_pytest
+parse_log_camel = parse_log_pytest
+parse_log_scrapy = parse_log_pytest
+parse_log_celery = parse_log_pytest
 
 parse_log_pydicom = parse_log_pytest_options
 parse_log_requests = parse_log_pytest_options
@@ -269,7 +275,11 @@ parse_log_sphinx = parse_log_pytest_v2
 
 MAP_REPO_TO_PARSER_PY = {
     "astropy/astropy": parse_log_astropy,
+    "camel-ai/camel": parse_log_camel,
+    "celery/celery": parse_log_celery,
     "django/django": parse_log_django,
+    "fastapi/fastapi": parse_log_fastapi,
+    "keras-team/keras": parse_log_keras,
     "marshmallow-code/marshmallow": parse_log_marshmallow,
     "matplotlib/matplotlib": parse_log_matplotlib,
     "mwaskom/seaborn": parse_log_seaborn,
@@ -282,8 +292,10 @@ MAP_REPO_TO_PARSER_PY = {
     "pylint-dev/pylint": parse_log_pylint,
     "pytest-dev/pytest": parse_log_pytest,
     "pyvista/pyvista": parse_log_pyvista,
+    "scrapy/scrapy": parse_log_scrapy,
     "scikit-learn/scikit-learn": parse_log_scikit,
     "sqlfluff/sqlfluff": parse_log_sqlfluff,
     "sphinx-doc/sphinx": parse_log_sphinx,
     "sympy/sympy": parse_log_sympy,
+    "ytdl-org/youtube-dl": parse_log_youtube,
 }

--- a/swebench/versioning/constants.py
+++ b/swebench/versioning/constants.py
@@ -1,8 +1,12 @@
 # Constants - Task Instance Version File
 MAP_REPO_TO_VERSION_PATHS = {
+    "camel-ai/camel": ["camel/__init__.py"],
+    "celery/celery": ["celery/__init__.py"],
     "dbt-labs/dbt-core": ["core/dbt/version.py", "core/dbt/__init__.py"],
     "django/django": ["django/__init__.py"],
+    "fastapi/fastapi": ["fastapi/__init__.py"],
     "huggingface/transformers": ["src/transformers/__init__.py"],
+    "keras-team/keras": ["keras/src/version.py"],
     "marshmallow-code/marshmallow": ["src/marshmallow/__init__.py"],
     "mwaskom/seaborn": ["seaborn/__init__.py"],
     "pallets/flask": ["src/flask/__init__.py", "flask/__init__.py"],
@@ -17,8 +21,10 @@ MAP_REPO_TO_VERSION_PATHS = {
     "pyvista/pyvista": ["pyvista/_version.py", "pyvista/__init__.py"],
     "Qiskit/qiskit": ["qiskit/VERSION.txt"],
     "scikit-learn/scikit-learn": ["sklearn/__init__.py"],
+    "scrapy/scrapy": ["scrapy/VERSION"],
     "sphinx-doc/sphinx": ["sphinx/__init__.py"],
     "sympy/sympy": ["sympy/release.py", "sympy/__init__.py"],
+    "ytdl-org/youtube-dl": ["youtube_dl/version.py"],
 }
 
 # Cosntants - Task Instance Version Regex Pattern
@@ -53,6 +59,16 @@ MAP_REPO_TO_VERSION_PATTERNS.update(
 MAP_REPO_TO_VERSION_PATTERNS.update({k: [r"(.*)"] for k in ["Qiskit/qiskit"]})
 MAP_REPO_TO_VERSION_PATTERNS.update(
     {k: [r"version_info = [\d]+,[\d\s]+,"] for k in ["pyvista/pyvista"]}
+)
+MAP_REPO_TO_VERSION_PATTERNS.update(
+    {k: [r"__version__ = ['\"](.*)['\"]", r"VERSION = \\((.*)\\)"]
+    for k in ["fastapi/fastapi", "ytdl-org/youtube-dl", "keras-team/keras", "camel-ai/camel"]}
+)
+MAP_REPO_TO_VERSION_PATTERNS.update(
+    {k: [r"(\S*)"] for k in ["scrapy/scrapy"]}
+)
+MAP_REPO_TO_VERSION_PATTERNS.update(
+    {k: [r"__version__ = ['\"](.*)['\"]"] for k in ["celery/celery"]}
 )
 
 SWE_BENCH_URL_RAW = "https://raw.githubusercontent.com/"


### PR DESCRIPTION
### Overview
I've onboarded the following repos from codearena to swebench for evaluation. 
These instances initially required running a monkeypatch script from OmniCode to add them to the swebench package; however, the script became outdated after we switched to running swebench from our forked repo and our migration to g2/unicorn. 

The repos onboarded include: 
- camel-ai/camel
- celery/celery
- fastapi/fastapi
- keras-team/keras
- scrapy/scrapy
- ytdl-org/youtube-dl

> I've already tested ALL the instances on g2, and all instances' gold patches pass codearena evaluation for bugfixing (these instances are also included in the g2_sane_instances_python.txt list in the OmniCode repo). 

#### Notes:
Feel free to look into the updates to get a grasp of what changes are required to onboard new python instances in the future. 