### PR TITLE
James/swebench unicorn compatibility enhancement

### DIFF
--- a/swebench/harness/apptainer_build.py
+++ b/swebench/harness/apptainer_build.py
@@ -74,7 +74,7 @@ def build_sandbox(dataset):
             
                 result = subprocess.run(
                     [APPTAINER_BASH, "exec", "--writable", "apptainer_sandbox", "bash", "-c", 
-                    f"cd apptainer_sandbox && bash /root/{setup_script_name}"],
+                    f"bash /root/{setup_script_name}"],
                     cwd=str(build_dir),
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,

--- a/swebench/harness/apptainer_build.py
+++ b/swebench/harness/apptainer_build.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 
-from swebench.harness.constants import DEF_IMAGE_BUILD_DIR, APPTAINER_BASH
+from swebench.harness.constants import DEF_IMAGE_BUILD_DIR, SCRATCH_DEF_IMAGE_BUILD_DIR, APPTAINER_BASH
 
 from swebench.harness.docker_build import (
     close_logger,
@@ -14,7 +14,7 @@ from swebench.harness.test_spec.test_spec import get_test_specs_from_dataset
 
 from swebench.harness.docker_build import BuildImageError
 
-def build_sandbox(dataset):
+def build_sandbox(dataset, local):
     test_specs = get_test_specs_from_dataset(dataset)
     for test_spec in test_specs:
         # build setup file and put in logs/instance_id folder
@@ -23,7 +23,10 @@ def build_sandbox(dataset):
                     "setup_repo.sh": test_spec.install_repo_script,
                 }
         
-        build_dir = DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
+        if local: 
+            build_dir = DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
+        else: 
+            build_dir = SCRATCH_DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
         logger = setup_logger("def", build_dir / "build_image.log")
         logger.info("Building image def\n")
 

--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -18,20 +18,20 @@ SHAREDIR = Path(f"/share/dutta/{USER}")
 SCRATCHDIR = Path(f"/scratch/{USER}")
 
 # Constants - Evaluation Log Directories (all under scratch now)
-BASE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/base"
-ENV_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/env"
-INSTANCE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/instances"
-DEF_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/def"
-RUN_EVALUATION_LOG_DIR = SCRATCHDIR / "logs/run_evaluation"
-RUN_VALIDATION_LOG_DIR = SCRATCHDIR / "logs/run_validation"
+SCRATCH_BASE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/base"
+SCRATCH_ENV_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/env"
+SCRATCH_INSTANCE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/instances"
+SCRATCH_DEF_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/def"
+SCRATCH_RUN_EVALUATION_LOG_DIR = SCRATCHDIR / "logs/run_evaluation"
+SCRATCH_RUN_VALIDATION_LOG_DIR = SCRATCHDIR / "logs/run_validation"
 
 # Constants - Evaluation Log Directories
-LOCAL_BASE_IMAGE_BUILD_DIR = Path("logs/build_images/base")
-LOCAL_ENV_IMAGE_BUILD_DIR = Path("logs/build_images/env")
-LOCAL_INSTANCE_IMAGE_BUILD_DIR = Path("logs/build_images/instances")
-LOCAL_DEF_IMAGE_BUILD_DIR = Path("logs/build_images/def")
-LOCAL_RUN_EVALUATION_LOG_DIR = Path("logs/run_evaluation")
-LOCAL_RUN_VALIDATION_LOG_DIR = Path("logs/run_validation")
+BASE_IMAGE_BUILD_DIR = Path("logs/build_images/base")
+ENV_IMAGE_BUILD_DIR = Path("logs/build_images/env")
+INSTANCE_IMAGE_BUILD_DIR = Path("logs/build_images/instances")
+DEF_IMAGE_BUILD_DIR = Path("logs/build_images/def")
+RUN_EVALUATION_LOG_DIR = Path("logs/run_evaluation")
+RUN_VALIDATION_LOG_DIR = Path("logs/run_validation")
 
 # Constants - Task Instance Class
 class SWEbenchInstance(TypedDict):

--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -12,14 +12,16 @@ from swebench.harness.constants.python import *
 from swebench.harness.constants.ruby import *
 from swebench.harness.constants.rust import *
 
+SHAREDIR = Path("/share/dutta/ejt82")
+SCRATCHDIR = Path("/scratch")
 
-# Constants - Evaluation Log Directories
-BASE_IMAGE_BUILD_DIR = Path("logs/build_images/base")
-ENV_IMAGE_BUILD_DIR = Path("logs/build_images/env")
-INSTANCE_IMAGE_BUILD_DIR = Path("logs/build_images/instances")
-DEF_IMAGE_BUILD_DIR = Path("logs/build_images/def")
-RUN_EVALUATION_LOG_DIR = Path("logs/run_evaluation")
-RUN_VALIDATION_LOG_DIR = Path("logs/run_validation")
+# Constants - Evaluation Log Directories (all under scratch now)
+BASE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/base"
+ENV_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/env"
+INSTANCE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/instances"
+DEF_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/def"
+RUN_EVALUATION_LOG_DIR = SCRATCHDIR / "logs/run_evaluation"
+RUN_VALIDATION_LOG_DIR = SCRATCHDIR / "logs/run_validation"
 
 
 # Constants - Task Instance Class

--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -12,8 +12,10 @@ from swebench.harness.constants.python import *
 from swebench.harness.constants.ruby import *
 from swebench.harness.constants.rust import *
 
-SHAREDIR = Path("/share/dutta/ejt82")
-SCRATCHDIR = Path("/scratch")
+import os
+USER = os.getenv("USER")
+SHAREDIR = Path(f"/share/dutta/{USER}")
+SCRATCHDIR = Path(f"/scratch/{USER}")
 
 # Constants - Evaluation Log Directories (all under scratch now)
 BASE_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/base"

--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -25,6 +25,13 @@ DEF_IMAGE_BUILD_DIR = SCRATCHDIR / "logs/build_images/def"
 RUN_EVALUATION_LOG_DIR = SCRATCHDIR / "logs/run_evaluation"
 RUN_VALIDATION_LOG_DIR = SCRATCHDIR / "logs/run_validation"
 
+# Constants - Evaluation Log Directories
+LOCAL_BASE_IMAGE_BUILD_DIR = Path("logs/build_images/base")
+LOCAL_ENV_IMAGE_BUILD_DIR = Path("logs/build_images/env")
+LOCAL_INSTANCE_IMAGE_BUILD_DIR = Path("logs/build_images/instances")
+LOCAL_DEF_IMAGE_BUILD_DIR = Path("logs/build_images/def")
+LOCAL_RUN_EVALUATION_LOG_DIR = Path("logs/run_evaluation")
+LOCAL_RUN_VALIDATION_LOG_DIR = Path("logs/run_validation")
 
 # Constants - Task Instance Class
 class SWEbenchInstance(TypedDict):

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -10,6 +10,7 @@ from swebench.harness.constants import (
     RUN_EVALUATION_LOG_DIR,
     SCRATCH_RUN_EVALUATION_LOG_DIR,
     LOG_REPORT,
+    SHAREDIR
 )
 from swebench.harness.docker_utils import list_images
 from swebench.harness.test_spec.test_spec import make_test_spec
@@ -139,9 +140,12 @@ def make_run_report(
                 "unremoved_images": list(sorted(unremoved_images)),
             }
         )
-    report_dir = Path(f"swebench_eval/{list(predictions.values())[0][KEY_MODEL].replace("/", "__")}" )
+    if local: 
+        report_dir = Path(f"swebench_eval/{list(predictions.values())[0][KEY_MODEL].replace("/", "__")}" )
+    else: 
+        report_dir = SHAREDIR / "logs/results"
     report_dir.mkdir(parents=True, exist_ok=True)
-    report_filename = f".{run_id}" + ".json"
+    report_filename = f"{instance_id}" + ".json"
     report_file = report_dir / report_filename
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -139,9 +139,9 @@ def make_run_report(
                 "unremoved_images": list(sorted(unremoved_images)),
             }
         )
-    report_dir = Path(f"swebench_eval/" )
+    report_dir = Path(f"swebench_eval/{list(predictions.values())[0][KEY_MODEL].replace("/", "__")}" )
     report_dir.mkdir(parents=True, exist_ok=True)
-    report_filename = list(predictions.values())[0][KEY_MODEL].replace("/", "__") + f".{run_id}" + ".json"
+    report_filename = f".{run_id}" + ".json"
     report_file = report_dir / report_filename
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -128,11 +128,10 @@ def make_run_report(
                 "unremoved_images": list(sorted(unremoved_images)),
             }
         )
-    report_file = Path(
-        list(predictions.values())[0][KEY_MODEL].replace("/", "__")
-        + f".{run_id}"
-        + ".json"
-    )
+    report_dir = Path(f"swebench_eval/" )
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_filename = list(predictions.values())[0][KEY_MODEL].replace("/", "__") + f".{run_id}" + ".json"
+    report_file = report_dir / report_filename
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)
     print(f"Report written to {report_file}")

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -2,6 +2,7 @@ import docker
 import json
 from pathlib import Path
 from typing import Optional
+import shutil
 
 from swebench.harness.constants import (
     KEY_INSTANCE_ID,
@@ -150,4 +151,16 @@ def make_run_report(
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)
     print(f"Report written to {report_file}")
+    if local:
+        logs_dir = (
+            SCRATCH_RUN_EVALUATION_LOG_DIR
+            / run_id
+            / prediction[KEY_MODEL].replace("/", "__")
+            / prediction[KEY_INSTANCE_ID]
+        )
+        dst = SHAREDIR / f"logs/{run_id}/{prediction[KEY_MODEL].replace("/", "__")}/{instance_id}"
+        dst.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(logs_dir, dst)
+        print(f"Removing logdir: {logs_dir} from scratch. ")
+        shutil.rmtree(logs_dir)
     return report_file

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -151,7 +151,7 @@ def make_run_report(
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)
     print(f"Report written to {report_file}")
-    if local:
+    if not local:
         logs_dir = (
             SCRATCH_RUN_EVALUATION_LOG_DIR
             / run_id

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -8,6 +8,7 @@ from swebench.harness.constants import (
     KEY_MODEL,
     KEY_PREDICTION,
     RUN_EVALUATION_LOG_DIR,
+    SCRATCH_RUN_EVALUATION_LOG_DIR,
     LOG_REPORT,
 )
 from swebench.harness.docker_utils import list_images
@@ -19,6 +20,7 @@ def make_run_report(
     full_dataset: list,
     run_id: str,
     client: Optional[docker.DockerClient] = None,
+    local: bool = False
 ) -> Path:
     """
     Make a final evaluation and run report of the instances that have been run.
@@ -55,13 +57,22 @@ def make_run_report(
         if prediction.get(KEY_PREDICTION, None) in ["", None]:
             empty_patch_ids.add(instance_id)
             continue
-        report_file = (
-            RUN_EVALUATION_LOG_DIR
-            / run_id
-            / prediction[KEY_MODEL].replace("/", "__")
-            / prediction[KEY_INSTANCE_ID]
-            / LOG_REPORT
-        )
+        if local: 
+            report_file = (
+                RUN_EVALUATION_LOG_DIR
+                / run_id
+                / prediction[KEY_MODEL].replace("/", "__")
+                / prediction[KEY_INSTANCE_ID]
+                / LOG_REPORT
+            )
+        else: 
+            report_file = (
+                SCRATCH_RUN_EVALUATION_LOG_DIR
+                / run_id
+                / prediction[KEY_MODEL].replace("/", "__")
+                / prediction[KEY_INSTANCE_ID]
+                / LOG_REPORT
+            )
         if report_file.exists():
             # If report file exists, then the instance has been run
             completed_ids.add(instance_id)

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -806,7 +806,7 @@ def main(
         print("No instances to run.")
     elif use_apptainer:
         # pull .sif + build sandbox with apptainer
-        build_sandbox(dataset)
+        build_sandbox(dataset, local=local)
         run_instance_apptainers(predictions, dataset, cache_level, clean, force_rebuild, max_workers, run_id, timeout, local)
     else:
         client = docker.from_env()

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -780,7 +780,7 @@ def main(
 
     # get dataset from predictions
     dataset = get_dataset_from_preds(
-        dataset_name, split, instance_ids, predictions, run_id, rewrite_reports, local
+        dataset_name, split, instance_ids, predictions, run_id, rewrite_reports, local=local
     )
     full_dataset = load_swebench_dataset(dataset_name, split, instance_ids)
 

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -83,7 +83,7 @@ def run_instance(
     run_id: str,
     timeout: int | None = None,
     rewrite_reports: bool = False,
-    local: bool = false
+    local: bool = False
 ):
     """
     Run a single instance with the given prediction.

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -19,9 +19,9 @@ from swebench.harness.constants import (
     DOCKER_USER,
     DOCKER_WORKDIR,
     INSTANCE_IMAGE_BUILD_DIR,
-    LOCAL_INSTANCE_IMAGE_BUILD_DIR,
+    SCRATCH_INSTANCE_IMAGE_BUILD_DIR,
     DEF_IMAGE_BUILD_DIR,
-    LOCAL_DEF_IMAGE_BUILD_DIR,
+    SCRATCH_DEF_IMAGE_BUILD_DIR,
     KEY_INSTANCE_ID,
     KEY_MODEL,
     KEY_PREDICTION,
@@ -29,7 +29,7 @@ from swebench.harness.constants import (
     LOG_INSTANCE,
     LOG_TEST_OUTPUT,
     RUN_EVALUATION_LOG_DIR,
-    LOCAL_RUN_EVALUATION_LOG_DIR,
+    SCRATCH_RUN_EVALUATION_LOG_DIR,
     UTF8,
     APPTAINER_BASH,
     SHAREDIR,
@@ -102,9 +102,9 @@ def run_instance(
     instance_id = test_spec.instance_id
     model_name_or_path = pred.get(KEY_MODEL, "None").replace("/", "__")
     if local:
-        log_dir = LOCAL_RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
-    else:
         log_dir = RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
+    else:
+        log_dir = SCRATCH_RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
 
     # Set up report file
     report_path = log_dir / LOG_REPORT
@@ -128,11 +128,11 @@ def run_instance(
     if not test_spec.is_remote_image:
         # Link the image build dir in the log dir
         if local: 
-            build_dir = LOCAL_INSTANCE_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(
+            build_dir = INSTANCE_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(
                 ":", "__"
             )
         else:
-            build_dir = INSTANCE_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(
+            build_dir = SCRATCH_INSTANCE_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(
                 ":", "__"
             )
         image_build_link = log_dir / "image_build_dir"
@@ -373,16 +373,16 @@ def run_instance_apptainer(
     # model_name_or_path = pred.get("model_name", "None").replace("/", "__")
     model_name_or_path = pred.get("model_name_or_path", "None").replace("/", "__")
     if local: 
-        log_dir = LOCAL_RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
-    else:
         log_dir = RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
+    else:
+        log_dir = SCRATCH_RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Link the image build dir in the log dir
     if local: 
-        build_dir = LOCAL_DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
-    else: 
         build_dir = DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
+    else: 
+        build_dir = SCRATCH_DEF_IMAGE_BUILD_DIR / test_spec.instance_image_key.replace(":", "__")
     image_build_link = log_dir / "image_build_dir"
     if not image_build_link.exists():
         try:
@@ -665,7 +665,7 @@ def get_dataset_from_preds(
             prediction = predictions[instance[KEY_INSTANCE_ID]]
             if local:
                 test_output_file = (
-                    LOCAL_RUN_EVALUATION_LOG_DIR
+                    RUN_EVALUATION_LOG_DIR
                     / run_id
                     / prediction["model_name_or_path"].replace("/", "__")
                     / prediction[KEY_INSTANCE_ID]
@@ -673,7 +673,7 @@ def get_dataset_from_preds(
                 )
             else:
                 test_output_file = (
-                    RUN_EVALUATION_LOG_DIR
+                    SCRATCH_RUN_EVALUATION_LOG_DIR
                     / run_id
                     / prediction["model_name_or_path"].replace("/", "__")
                     / prediction[KEY_INSTANCE_ID]
@@ -699,7 +699,7 @@ def get_dataset_from_preds(
         prediction = predictions[instance[KEY_INSTANCE_ID]]
         if local:    
             report_file = (
-                LOCAL_RUN_EVALUATION_LOG_DIR
+                RUN_EVALUATION_LOG_DIR
                 / run_id
                 / prediction[KEY_MODEL].replace("/", "__")
                 / prediction[KEY_INSTANCE_ID]
@@ -707,7 +707,7 @@ def get_dataset_from_preds(
             )
         else:
             report_file = (
-                RUN_EVALUATION_LOG_DIR
+                SCRATCH_RUN_EVALUATION_LOG_DIR
                 / run_id
                 / prediction[KEY_MODEL].replace("/", "__")
                 / prediction[KEY_INSTANCE_ID]


### PR DESCRIPTION
SWE-bench for Unicorn/g2 compatibility: 
- added argument "local" to specify whether user is running on g2/unicorn or locally (default local = False, because I'm assuming all experiments and evaluation should be run on unicorn)
- For local = False, the working directory and intermediate files are written to scratch, and the final reports are written to share (with an additional copy written to ./swebench_eval just in case)  
- For local = True, files are written to Omnicode/logs (original default output directories)

@wellslu If possible, do help me review and test out the code to see if it works for you on unicorn. 
Relevant changes to codearena.py in OmniCode can be found on the branch: `James/swebench-unicorn-compatible-enhancement`